### PR TITLE
Fix minor style issues

### DIFF
--- a/styles/dcc.css
+++ b/styles/dcc.css
@@ -837,7 +837,7 @@
 /*  Warrior Class                            */
 /* ----------------------------------------- */
 .dcc .crit-range {
-  margin: 0 0 0 4px; }
+  margin: 12px 0 0 4px; }
 
 .dcc .crit-range label {
   margin: 0 0 0 4px;

--- a/styles/dcc.css
+++ b/styles/dcc.css
@@ -958,4 +958,5 @@
   flex: 1 1; }
 
 .dcc.item .item-type {
-  flex: 0 0 60px; }
+  flex: 0 0 60px;
+  margin: 5px 0 0 5px; }

--- a/styles/dcc.scss
+++ b/styles/dcc.scss
@@ -934,7 +934,7 @@
 /* ----------------------------------------- */
 
 .dcc .crit-range {
-  margin: 0 0 0 4px;
+  margin: 12px 0 0 4px;
 }
 
 .dcc .crit-range label {

--- a/styles/dcc.scss
+++ b/styles/dcc.scss
@@ -1088,6 +1088,7 @@
 
   .item-type {
     flex: 0 0 60px;
+    margin: 5px 0 0 5px;
   }
 }
 

--- a/templates/actor-partial-cleric-spells.html
+++ b/templates/actor-partial-cleric-spells.html
@@ -8,7 +8,7 @@
               <div class="item-level">{{localize "DCC.SpellLevelShort"}}</div>
               <div class="item-name">{{localize "DCC.SpellName"}}</div>
               <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="spell"><i class="fas fa-plus"></i> Add item</a>
+                <a class="item-control item-create" title="Create item" data-type="spell"><i class="fas fa-plus"></i> Add</a>
               </div>
             </li>
             {{#each actor.spells as |spells spelllevel|}}

--- a/templates/actor-partial-pc-common.html
+++ b/templates/actor-partial-pc-common.html
@@ -93,6 +93,7 @@
                     <input class="init-value" type="text" id="data.attributes.init.value"
                            name="data.attributes.init.value"
                            value="{{numberFormat data.attributes.init.value decimals=0 sign=true}}"
+                           placeholder="+0"
                            data-dtype="Number"/>
                 </div>
                 <div class="speed">
@@ -115,12 +116,14 @@
                 <div class="crit-die">
                     <label for="data.attributes.critical.die">{{localize "DCC.CritDie"}}</label>
                     <input type="text" id="data.attributes.critical.die" name="data.attributes.critical.die"
-                           value="{{data.attributes.critical.die}}" maxlength="40"/>
+                           value="{{data.attributes.critical.die}}" maxlength="40"
+                           placeholder="1d4"/>
                 </div>
                 <div class="crit-table">
                     <label for="data.attributes.critical.table">{{localize "DCC.CritTable"}}</label>
                     <input type="text" id="data.attributes.critical.table" name="data.attributes.critical.table"
-                           value="{{data.attributes.critical.table}}" maxlength="40"/>
+                           value="{{data.attributes.critical.table}}" maxlength="40"
+                           placeholder="I"/>
                 </div>
             </li>
         </ul>

--- a/templates/actor-partial-pc-equipment.html
+++ b/templates/actor-partial-pc-equipment.html
@@ -91,7 +91,7 @@
       <div class="item-weight">{{localize "DCC.Weight"}}</div>
       <div class="item-quantity">{{localize "DCC.Quantity"}}</div>
       <div class="item-controls">
-        <a class="item-control item-create" title="Create item" data-type="{{type}}"><i class="fas fa-plus"></i> Add item</a>
+        <a class="item-control item-create" title="Create item" data-type="{{type}}"><i class="fas fa-plus"></i> Add</a>
       </div>
     </li>
     {{/inline}}

--- a/templates/actor-partial-pc-header.html
+++ b/templates/actor-partial-pc-header.html
@@ -37,7 +37,8 @@
         <div class="experience">
             <label for="data.details.experience.value">{{localize "DCC.Experience"}}</label>
             <input type="text" id="data.details.experience.value" name="data.details.experience.value"
-                   value="{{data.details.experience.value}}" maxlength="40"/>
+                   value="{{numberFormat data.details.experience.value decimals=0 sign=false}}"
+                   maxlength="40" data-dtype="Number"/>
         </div>
     </div>
 </header>

--- a/templates/actor-partial-pc-header.html
+++ b/templates/actor-partial-pc-header.html
@@ -38,7 +38,7 @@
             <label for="data.details.experience.value">{{localize "DCC.Experience"}}</label>
             <input type="text" id="data.details.experience.value" name="data.details.experience.value"
                    value="{{numberFormat data.details.experience.value decimals=0 sign=false}}"
-                   maxlength="40" data-dtype="Number"/>
+                   placeholder="0" maxlength="40" data-dtype="Number"/>
         </div>
     </div>
 </header>

--- a/templates/actor-partial-wizard-spells.html
+++ b/templates/actor-partial-wizard-spells.html
@@ -9,7 +9,7 @@
               <div class="item-name">{{localize "DCC.SpellName"}}</div>
               <div class="item-notes">{{localize "DCC.MercurialEffect"}}</div>
               <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="spell"><i class="fas fa-plus"></i> Add item</a>
+                <a class="item-control item-create" title="Create item" data-type="spell"><i class="fas fa-plus"></i> Add</a>
               </div>
             </li>
             {{#each actor.spells as |spells spelllevel|}}

--- a/templates/actor-sheet-halfling.html
+++ b/templates/actor-sheet-halfling.html
@@ -35,8 +35,16 @@
                 </div>
 
                 <ul class="class-note flexcol">
+                  <li>{{localize "DCC.Infravision"}}</li>
                   <li>{{localize "DCC.Lucky"}}</li>
-                  <li>{{localize "DCC.TwoWeaponFighting"}}</li>
+                  <li>{{localize "DCC.TwoWeaponFighting"}}
+                    <ul class="class-note flexcol">
+                      <li>Action dice d16+d16</li>
+                      <li>Crit on nat 16</li>
+                      <li>Fumble only on 2x 1</li>
+                      <li>If Agi &gt; 16 use normal rules</li>
+                    </ul>
+                  </li>
                 </ul>
             </div>
         </div>

--- a/templates/actor-sheet-zero-level.html
+++ b/templates/actor-sheet-zero-level.html
@@ -31,7 +31,7 @@
                 <label for="data.details.experience.value">{{localize "DCC.Experience"}}</label>
                 <input type="text" id="data.details.experience.value" name="data.details.experience.value"
                        value="{{numberFormat data.details.experience.value decimals=0 sign=false}}"
-                       maxlength="40" data-dtype="Number"/>
+                       placeholder="0" maxlength="40" data-dtype="Number"/>
             </div>
         </div>
     </header>
@@ -115,6 +115,7 @@
                             <input class="init-value" type="text" id="data.attributes.init.value"
                                    name="data.attributes.init.value"
                                    value="{{numberFormat data.attributes.init.value decimals=0 sign=true}}"
+                                   placeholder="+0"
                                    data-dtype="Number"/>
                         </div>
                         <div class="speed">

--- a/templates/actor-sheet-zero-level.html
+++ b/templates/actor-sheet-zero-level.html
@@ -30,7 +30,8 @@
             <div class="experience">
                 <label for="data.details.experience.value">{{localize "DCC.Experience"}}</label>
                 <input type="text" id="data.details.experience.value" name="data.details.experience.value"
-                       value="{{data.details.experience.value}}" maxlength="40"/>
+                       value="{{numberFormat data.details.experience.value decimals=0 sign=false}}"
+                       maxlength="40" data-dtype="Number"/>
             </div>
         </div>
     </header>


### PR DESCRIPTION
Fixes for #21, #23, #27, #28, #31, #32, and #34.

I can't reproduce the clipping issue on the item/spell sheet (I've tried Firefox, Chrome or Electron on Windows or on a friend's Mac under Firefox). I suspect it's specific to Linux but all my available Linux boxes run headless so I'm unable to check.

@ckwk if you're able to confirm these fixed that would be much appreciated.