### PR TITLE
Prevent test failures from cascading.

### DIFF
--- a/module/__tests__/actor.test.js
+++ b/module/__tests__/actor.test.js
@@ -32,6 +32,8 @@ test('prepareData sets ability modifiers', () => {
 })
 
 test('roll ability check', () => {
+  Roll.mockClear()
+
   actor.rollAbilityCheck('str')
   expect(Roll).toHaveBeenCalledTimes(1)
   expect(Roll).toHaveBeenCalledWith('1d20+@abilMod', { abilMod: -1, critical: 20 })
@@ -48,11 +50,11 @@ test('roll ability check', () => {
   expect(Roll).toHaveBeenCalledTimes(3)
   expect(Roll).toHaveBeenCalledWith('1d20+@abilMod', { abilMod: -1, critical: 20 })
   expect(rollToMessageMock).toHaveBeenLastCalledWith({ flavor: 'AbilityLck Check', speaker: actor })
-
-  Roll.mockClear()
 })
 
 test('roll saving throw', () => {
+  Roll.mockClear()
+
   actor.rollSavingThrow('frt')
   expect(Roll).toHaveBeenCalledTimes(1)
   expect(Roll).toHaveBeenCalledWith('1d20+@saveMod', { saveMod: -1 })
@@ -67,20 +69,22 @@ test('roll saving throw', () => {
   expect(Roll).toHaveBeenCalledTimes(3)
   expect(Roll).toHaveBeenCalledWith('1d20+@saveMod', { saveMod: +12 })
   expect(rollToMessageMock).toHaveBeenCalledWith({ flavor: 'SavesWill Save', speaker: actor })
-
-  Roll.mockClear()
 })
 
 test('roll initiative', () => {
+  Roll.mockClear()
+
   actor.rollInitiative()
   expect(Roll).toHaveBeenCalledTimes(1)
   expect(Roll).toHaveBeenCalledWith('1d20+@init', { init: -1 })
   expect(rollToMessageMock).toHaveBeenCalledWith({ flavor: 'Initiative', speaker: actor })
-
-  Roll.mockClear()
 })
 
 test('roll weapon attack', () => {
+  Roll.mockClear()
+  collectionFindMock.mockClear()
+  uiNotificationsWarnMock.mockClear()
+
   // Roll a weapon we don't have
   actor.rollWeaponAttack('r123')
   expect(collectionFindMock).toHaveBeenCalledTimes(1)
@@ -133,13 +137,11 @@ test('roll weapon attack', () => {
     content: 'AttackRollEmote,weaponName:longsword,rollHTML:<a class="inline-roll inline-result" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%7D%5D%7D" title="1d20 + 1"><i class="fas fa-dice-d20"></i> undefined</a>,damageRollHTML:<a class="inline-roll inline-result damage-applyable" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%7D%5D%7D" data-damage="undefined" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,crit:,fumble:[object Object]',
     sound: 'diceSound'
   })
-
-  Roll.mockClear()
-  collectionFindMock.mockReset()
-  uiNotificationsWarnMock.mockClear()
 })
 
 test('roll skill check', () => {
+  Roll.mockClear()
+
   actor.rollSkillCheck('customDieSkill')
   expect(Roll).toHaveBeenCalledTimes(1)
   expect(Roll).toHaveBeenCalledWith('1d14')
@@ -169,18 +171,20 @@ test('roll skill check', () => {
   expect(Roll).toHaveBeenCalledTimes(6)
   expect(Roll).toHaveBeenCalledWith('1d20+@bonus', { bonus: -4 })
   expect(rollToMessageMock).toHaveBeenCalledWith({ flavor: 'Action Die Skill With Lck (AbilityLck)', speaker: actor })
-
-  Roll.mockClear()
 })
 
 test('roll luck die', () => {
+  Roll.mockClear()
+
   actor.rollLuckDie()
   expect(Roll).toHaveBeenCalledTimes(1)
-
-  Roll.mockClear()
 })
 
 test('roll spell check', () => {
+  Roll.mockClear()
+  collectionFindMock.mockReset()
+  uiNotificationsWarnMock.mockReset()
+
   // Spell check with ability from actor data
   actor.rollSpellCheck()
   expect(Roll).toHaveBeenCalledTimes(1)
@@ -224,6 +228,4 @@ test('roll spell check', () => {
   expect(dccItemRollSpellCheckMock).toHaveBeenCalledWith('int')
   expect(uiNotificationsWarnMock).toHaveBeenCalledTimes(2)
   expect(uiNotificationsWarnMock).toHaveBeenCalledWith('SpellCheckNoOwnedItemWarning')
-
-  Roll.mockClear()
 })


### PR DESCRIPTION
Clear mocks before the tests that expect to use or query them.