### PR TITLE
Fix horizontal borders on the tab labels within the DCC sheet (in 0.7.4)

### DIFF
--- a/styles/dcc.css
+++ b/styles/dcc.css
@@ -1114,3 +1114,9 @@
   text-shadow: none;
   border-bottom: none;
   margin-bottom: 11px; }
+
+/* ----------------------------------------- */
+/*  Fix sheet tabs in 0.7.4                  */
+/* ----------------------------------------- */
+.dcc.sheet .sheet-tabs.tabs {
+  border: none; }

--- a/styles/dcc.scss
+++ b/styles/dcc.scss
@@ -1323,3 +1323,13 @@ $border-style: 2px groove #eeede0;
   }
 }
 
+/* ----------------------------------------- */
+/*  Fix sheet tabs in 0.7.4                  */
+/* ----------------------------------------- */
+
+.dcc.sheet {
+  .sheet-tabs.tabs {
+    border: none;
+  }
+}
+


### PR DESCRIPTION
Closes #84 
Tested on 0.7.4 and 0.6.6.