### PR TITLE
Add weapon specific critRange.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -347,7 +347,6 @@
   "DCC.LanguagesHalfling": "Halfling",
   "DCC.LanguagesOrc": "Orc",
   "DCC.LanguagesThievesCant": "Thieves' Cant",
-  "DCC.LayOnHands": "Lay On Hands",
   "DCC.LayOnHands": "Lay on Hands",
   "DCC.Level": "Level",
   "DCC.LimitedUses": "Limited Uses",

--- a/lang/en.json
+++ b/lang/en.json
@@ -568,6 +568,7 @@
   "DCC.WeaponNotFound" : "Unable to find a weapon with id '{id}'.",
   "DCC.WeaponPropertiesBackstab": "Backstab",
   "DCC.WeaponPropertiesBackstabDamage": "Backstab Damage",
+  "DCC.WeaponPropertiesCritOn": "Crit on",
   "DCC.WeaponPropertiesDamage": "Damage",
   "DCC.WeaponPropertiesToHit": "To Hit",
   "DCC.WeaponPropertiesMelee": "Melee",

--- a/module/__tests__/actor.test.js
+++ b/module/__tests__/actor.test.js
@@ -137,6 +137,18 @@ test('roll weapon attack', () => {
     content: 'AttackRollEmote,weaponName:longsword,rollHTML:<a class="inline-roll inline-result" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,damageRollHTML:<a class="inline-roll inline-result damage-applyable" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" data-damage="undefined" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,crit:,fumble:[object Object]',
     sound: 'diceSound'
   })
+
+  collectionFindMock.mockReturnValue(new DCCItem('lefthand dagger', {
+    type: 'weapon',
+    data: {
+      actionDie: '1d16',
+      toHit: 2,
+      critRange: 16,
+      melee: true
+    }
+  }))
+  actor.rollWeaponAttack('lefthand dagger')
+  expect(Roll).toHaveBeenCalledWith('1d16 + 2', { ab: 0, critical: 16 })
 })
 
 test('roll skill check', () => {

--- a/module/actor.js
+++ b/module/actor.js
@@ -418,7 +418,7 @@ class DCCActor extends Actor {
     }
 
     /* Determine crit range */
-    const critRange = this.data.data.details.critRange || 20
+    const critRange = weapon.data.data.critRange || this.data.data.details.critRange || 20
 
     /* Roll the Attack */
     const roll = new Roll(formula, { ab: attackBonus, critical: critRange })

--- a/module/item.js
+++ b/module/item.js
@@ -13,6 +13,7 @@ class DCCItem extends Item {
       // Weapons can inherit the owner's action die
       if (this.data.data.config.inheritActionDie) {
         this.data.data.actionDie = this.actor.data.data.attributes.actionDice.value
+        this.data.data.critRange = this.actor.data.data.critRange
       }
 
       // Spells can inherit the owner's spell check

--- a/module/item.js
+++ b/module/item.js
@@ -13,7 +13,7 @@ class DCCItem extends Item {
       // Weapons can inherit the owner's action die
       if (this.data.data.config.inheritActionDie) {
         this.data.data.actionDie = this.actor.data.data.attributes.actionDice.value
-        this.data.data.critRange = this.actor.data.data.critRange
+        this.data.data.critRange = this.actor.data.data.details.critRange
       }
 
       // Spells can inherit the owner's spell check

--- a/templates/item-sheet-weapon.html
+++ b/templates/item-sheet-weapon.html
@@ -9,7 +9,7 @@
                 <label class="item-type" for="name">{{localize item.data.typeString}}</label>
             </div>
 
-            <div class="grid grid-2col">
+            <div class="grid grid-3col">
               <div class="resource">
                 <label class="resource-label" for="data.toHit">{{localize "DCC.WeaponPropertiesToHit"}}</label>
                 <div class="flexrow">
@@ -17,6 +17,10 @@
                          value="{{data.actionDie}}"
                          {{#if data.config.inheritActionDie}}disabled{{/if}}
                          placeholder="1d20" data-dtype="String"/>
+                  <input type="text" name="data.critRange" class="flex1"
+                         value="{{data.critRange}}"
+                         {{#if data.config.inheritActionDie}}disabled{{/if}}
+                         placeholder="20" data-dtype="Number"/>
                   <input type="text" name="data.toHit" class="flex1"
                          value="{{data.toHit}}"
                          placeholder="+0" data-dtype="String"/>

--- a/templates/item-sheet-weapon.html
+++ b/templates/item-sheet-weapon.html
@@ -17,14 +17,17 @@
                          value="{{data.actionDie}}"
                          {{#if data.config.inheritActionDie}}disabled{{/if}}
                          placeholder="1d20" data-dtype="String"/>
-                  <input type="text" name="data.critRange" class="flex1"
-                         value="{{data.critRange}}"
-                         {{#if data.config.inheritActionDie}}disabled{{/if}}
-                         placeholder="20" data-dtype="Number"/>
                   <input type="text" name="data.toHit" class="flex1"
                          value="{{data.toHit}}"
                          placeholder="+0" data-dtype="String"/>
                 </div>
+              </div>
+              <div class="resource">
+                <label class="resource-label" for="data.critRange">{{localize "DCC.WeaponPropertiesCritOn"}}</label>
+                <input type="text" name="data.critRange"
+                       value="{{data.critRange}}"
+                       {{#if data.config.inheritActionDie}}disabled{{/if}}
+                       placeholder="20" data-dtype="Number"/>
               </div>
               <div class="resource">
                 <label class="resource-label" for="data.level">{{localize "DCC.WeaponPropertiesDamage"}}</label>

--- a/templates/item-sheet-weapon.html
+++ b/templates/item-sheet-weapon.html
@@ -9,25 +9,27 @@
                 <label class="item-type" for="name">{{localize item.data.typeString}}</label>
             </div>
 
-            <div class="grid grid-3col">
-              <div class="resource">
-                <label class="resource-label" for="data.toHit">{{localize "DCC.WeaponPropertiesToHit"}}</label>
-                <div class="flexrow">
-                  <input type="text" name="data.actionDie" class="flex1"
-                         value="{{data.actionDie}}"
+            <div class="grid grid-2col">
+              <div class="flexrow">
+                <div class="resource">
+                  <label class="resource-label" for="data.critRange">{{localize "DCC.WeaponPropertiesCritOn"}}</label>
+                  <input type="text" name="data.critRange"
+                         value="{{data.critRange}}"
                          {{#if data.config.inheritActionDie}}disabled{{/if}}
-                         placeholder="1d20" data-dtype="String"/>
-                  <input type="text" name="data.toHit" class="flex1"
-                         value="{{data.toHit}}"
-                         placeholder="+0" data-dtype="String"/>
+                         placeholder="20" data-dtype="Number"/>
                 </div>
-              </div>
-              <div class="resource">
-                <label class="resource-label" for="data.critRange">{{localize "DCC.WeaponPropertiesCritOn"}}</label>
-                <input type="text" name="data.critRange"
-                       value="{{data.critRange}}"
-                       {{#if data.config.inheritActionDie}}disabled{{/if}}
-                       placeholder="20" data-dtype="Number"/>
+                <div class="resource">
+                  <label class="resource-label" for="data.toHit">{{localize "DCC.WeaponPropertiesToHit"}}</label>
+                  <div class="flexrow">
+                    <input type="text" name="data.actionDie" class="flex1"
+                           value="{{data.actionDie}}"
+                           {{#if data.config.inheritActionDie}}disabled{{/if}}
+                           placeholder="1d20" data-dtype="String"/>
+                    <input type="text" name="data.toHit" class="flex1"
+                           value="{{data.toHit}}"
+                           placeholder="+0" data-dtype="String"/>
+                  </div>
+                </div>    
               </div>
               <div class="resource">
                 <label class="resource-label" for="data.level">{{localize "DCC.WeaponPropertiesDamage"}}</label>


### PR DESCRIPTION
Suggestion how to implement two weapon fighting crits for halflings or other classes.

The inherit flag for the action die controls also the inheritance of the critRange for the attack. If this is disabled the user is able to define a weapon specific critRange (added box to weapon sheet) that overrides the characters critRange.

This way it is possible for halflings to define a d16 with critRange 16 on all weapons they wield dual handed. This is also usable for other dual wielding characters with a very high dex (which means they want to allow crits on the main hand only).