### PR TITLE
Roll crits and fumbles exactly once so the dice roll shown matches the table result.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -248,6 +248,7 @@
   "DCC.FlagsTitle": "Configure Special Traits",
   "DCC.ForgeDocument": "Forge Document",
   "DCC.Formula": "Formula",
+  "DCC.Fumble": "Fumble",
   "DCC.FumbleDie": "Fumble Die",
   "DCC.Generic": "Generic",
   "DCC.GrantedAbilities": "Granted Abilities",

--- a/module/__tests__/actor.test.js
+++ b/module/__tests__/actor.test.js
@@ -111,7 +111,7 @@ test('roll weapon attack', () => {
     user: 1,
     speaker: { alias: 'test character', _id: 1 },
     type: 'emote',
-    content: 'AttackRollEmote,weaponName:longsword,rollHTML:<a class="inline-roll inline-result" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,damageRollHTML:<a class="inline-roll inline-result damage-applyable" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" data-damage="undefined" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,crit:,fumble:[object Object]',
+    content: 'AttackRollEmote,weaponName:longsword,rollHTML:<a class="inline-roll inline-result" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%22dcc%22%3A%7B%22upperThreshold%22%3A20%7D%7D%7D%5D%7D" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,damageRollHTML:<a class="inline-roll inline-result damage-applyable" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" data-damage="undefined" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,crit:,fumble:[object Object]',
     sound: 'diceSound'
   })
 
@@ -134,7 +134,7 @@ test('roll weapon attack', () => {
     user: 1,
     speaker: { alias: 'test character', _id: 1 },
     type: 'emote',
-    content: 'AttackRollEmote,weaponName:longsword,rollHTML:<a class="inline-roll inline-result" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,damageRollHTML:<a class="inline-roll inline-result damage-applyable" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" data-damage="undefined" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,crit:,fumble:[object Object]',
+    content: 'AttackRollEmote,weaponName:longsword,rollHTML:<a class="inline-roll inline-result" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%22dcc%22%3A%7B%22upperThreshold%22%3A20%7D%7D%7D%5D%7D" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,damageRollHTML:<a class="inline-roll inline-result damage-applyable" data-roll="%7B%22dice%22%3A%5B%7B%22results%22%3A%5B10%5D%2C%22options%22%3A%7B%7D%7D%5D%7D" data-damage="undefined" title="undefined"><i class="fas fa-dice-d20"></i> undefined</a>,crit:,fumble:[object Object]',
     sound: 'diceSound'
   })
 

--- a/module/actor-sheets-dcc.js
+++ b/module/actor-sheets-dcc.js
@@ -1,3 +1,5 @@
+/* global game */
+
 /**
  * DCC specific character sheet overrides
  */

--- a/module/item.js
+++ b/module/item.js
@@ -17,9 +17,9 @@ class DCCItem extends Item {
 
       // Set default inherit crit range for legacy items
       if (this.data.data.config.inheritCritRange === undefined) {
-        this.data.data.config.inheritCritRange == true
+        this.data.data.config.inheritCritRange = true
         this.update({
-          "data.config.inheritCritRange": true
+          'data.config.inheritCritRange': true
         })
       }
 
@@ -30,11 +30,11 @@ class DCCItem extends Item {
         // If not inheriting crit range make sure there is a value (for legacy items)
         if (this.data.data.critRange === null || this.data.data.critRange === undefined) {
           this.update({
-            "data.critRange": 20
+            'data.critRange': 20
           })
         }
       }
-        
+
       // Spells can inherit the owner's spell check
       if (this.data.data.config.inheritSpellCheck) {
         this.data.data.spellCheck.value = this.actor.data.data.class.spellCheck

--- a/module/migrations.js
+++ b/module/migrations.js
@@ -110,7 +110,7 @@ export const migrateActorData = function (actor) {
     // Add useDisapprovalRange to cleric skills
     'data.skills.divineAid.useDisapprovalRange': true,
     'data.skills.turnUnholy.useDisapprovalRange': true,
-    'data.skills.layOnHands.useDisapprovalRange': true,
+    'data.skills.layOnHands.useDisapprovalRange': true
   }
 
   // Migrate Owned Items


### PR DESCRIPTION
Ensure crits and fumbles are displayed correctly when using standard
cards with no tables setup.
Add localised string for 'Fumble'.
Closes #109.