### PR TITLE
Restore spell deletion on the wizard sheet

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -431,7 +431,7 @@ class DCCActor extends Actor {
     if (displayStandardCards) {
       roll.toMessage({
         speaker: ChatMessage.getSpeaker({ actor: this }),
-        flavor: game.i18n.localize('DCC.AttackRoll')
+        flavor: game.i18n.localize(backstab ? 'DCC.Backstab' : 'DCC.AttackRoll')
       })
     }
 
@@ -450,7 +450,7 @@ class DCCActor extends Actor {
     if (displayStandardCards) {
       damageRoll.toMessage({
         speaker: ChatMessage.getSpeaker({ actor: this }),
-        flavor: game.i18n.localize(backstab ? 'DCC.Backstab' : 'DCC.DamageRoll')
+        flavor: game.i18n.localize('DCC.DamageRoll')
       })
     }
 

--- a/system.json
+++ b/system.json
@@ -2,9 +2,9 @@
   "name": "dcc",
   "title": "Dungeon Crawl Classics",
   "description": "Dungeon Crawl Classics from Goodman Games",
-  "version": 0.19,
+  "version": 0.20,
   "minimumCoreVersion": "0.6.6",
-  "compatibleCoreVersion": "0.7.8",
+  "compatibleCoreVersion": "0.7.9",
   "templateVersion": 2,
   "author": "Tim L. White",
   "contributors": { "name" : "Steve Barnett", "email" : "mooped@gmail.com" },
@@ -29,6 +29,6 @@
   "initiative": "1d20 + @attributes.init.value",
   "url": "https://github.com/cyface/foundryvtt-dcc",
   "manifest": "https://github.com/cyface/foundryvtt-dcc/raw/master/system.json",
-  "download": "https://github.com/cyface/foundryvtt-dcc/archive/v0.0.19.zip",
+  "download": "https://github.com/cyface/foundryvtt-dcc/archive/v0.0.20.zip",
   "license": "LICENSE.txt"
 }

--- a/templates/actor-partial-cleric-spells.html
+++ b/templates/actor-partial-cleric-spells.html
@@ -18,7 +18,10 @@
                 data-ability="per" data-die="{{item.data.spellCheck.die}}"
                 data-bonus="{{item.data.spellCheck.value}}"
                 data-spell="{{item.name}}">
-                <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
+                <div class="item-image flexrow">
+                  <img class="flex1" src="{{item.img}}" title="{{item.name}}"
+                    width="24" height="24"/>
+                </div>
                 <div class="rollable spell-item-button">&nbsp;</div>
                 <h4 class="item-level">{{item.data.level}}</h4>
                 <h4 class="item-name flex3">{{item.name}}</h4>

--- a/templates/actor-partial-pc-equipment.html
+++ b/templates/actor-partial-pc-equipment.html
@@ -145,7 +145,7 @@
     {{/inline}}
     {{#* inline "ItemRow"}}
     <li class="item flexrow" data-item-id="{{item._id}}">
-        <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
+        <div class="item-image flexrow"><img class="flex1" src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
         <h4 class="item-name flex3">{{item.name}}</h4>
         <h4 class="item-weight flex3">{{item.data.weight}}</h4>
         <h4 class="item-quantity flex1">{{item.data.quantity}}</h4>
@@ -184,7 +184,7 @@
     {{!-- Treasure --}}
     {{#* inline "TreasureRow"}}
     <li class="item flexrow" data-item-id="{{item._id}}">
-        <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
+        <div class="item-image flexrow"><img class="flex1" src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
         <h4 class="item-name">{{item.name}}</h4>
         <h4 class="item-is-coins">{{#if item.data.isCoins}}({{localize "DCC.AsCoins"}}){{/if}}</h4>
         <h4 class="item-pp">{{item.data.value.pp}}</h4>

--- a/templates/actor-partial-wizard-spells.html
+++ b/templates/actor-partial-wizard-spells.html
@@ -35,7 +35,7 @@
                 </h4>
                 <div class="item-controls">
                     <a class="item-control item-edit" title="{{localize 'DCC.ItemEdit'}}"><i class="fas fa-edit"></i></a>
-                    <a class="" title="{{localize 'DCC.ItemDelete'}}"><i class="fas fa-trash"></i></a>
+                    <a class="item-control item-delete" title="{{localize 'DCC.ItemDelete'}}"><i class="fas fa-trash"></i></a>
                 </div>
             </li>
             {{/each}}

--- a/templates/actor-sheet-npc.html
+++ b/templates/actor-sheet-npc.html
@@ -270,7 +270,7 @@
             {{/inline}}
             {{#* inline "ItemRow"}}
             <li class="item flexrow" data-item-id="{{item._id}}">
-                <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
+                <div class="item-image flexrow"><img class="flex1" src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
                 <h4 class="item-name flex3">{{item.name}}</h4>
                 <h4 class="item-weight flex3">{{item.data.weight}}</h4>
                 <h4 class="item-quantity flex1">{{item.data.quantity}}</h4>
@@ -309,7 +309,7 @@
             {{!-- Treasure --}}
             {{#* inline "TreasureRow"}}
             <li class="item flexrow" data-item-id="{{item._id}}">
-                <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
+                <div class="item-image flexrow"><img class="flex1" src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
                 <h4 class="item-name">{{item.name}}</h4>
                 <h4 class="item-is-coins">{{#if item.data.isCoins}}({{localize "DCC.AsCoins"}}){{/if}}</h4>
                 <h4 class="item-pp">{{item.data.value.pp}}</h4>

--- a/templates/actor-sheet-zero-level.html
+++ b/templates/actor-sheet-zero-level.html
@@ -275,7 +275,7 @@
             {{/inline}}
             {{#* inline "ItemRow"}}
             <li class="item flexrow" data-item-id="{{item._id}}">
-                <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
+                <div class="item-image flexrow"><img class="flex1" src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
                 <h4 class="item-name flex3">{{item.name}}</h4>
                 <h4 class="item-weight flex3">{{item.data.weight}}</h4>
                 <h4 class="item-quantity flex1">{{item.data.quantity}}</h4>
@@ -314,7 +314,7 @@
             {{!-- Treasure --}}
             {{#* inline "TreasureRow"}}
             <li class="item flexrow" data-item-id="{{item._id}}">
-                <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
+                <div class="item-image flexrow"><img class="flex1" src="{{item.img}}" title="{{item.name}}" width="24" height="24"/></div>
                 <h4 class="item-name">{{item.name}}</h4>
                 <h4 class="item-is-coins">{{#if item.data.isCoins}}({{localize "DCC.AsCoins"}}){{/if}}</h4>
                 <h4 class="item-pp">{{item.data.value.pp}}</h4>


### PR DESCRIPTION
Also correctly constrain the size of item icons in the equipment tab.
Tweak backstab callout when using standard cards.
Version bump to 0.20 and compatibility bump to 0.7.9.
Closes #114 

This is ready for a release.